### PR TITLE
Fixed a typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "atom-debugger",
   "main": "./lib/debugger",
   "version": "0.1.6",
-  "description": "GDB debbuger for Atom",
+  "description": "GDB debugger for Atom",
   "activationCommands": {
     "atom-workspace": "debugger:toggle"
   },


### PR DESCRIPTION
This typo was visible from the package installer in atom right below the title.